### PR TITLE
refactor: Adding sub and partial routing to use task list as main page

### DIFF
--- a/task-manager/src/app/app.html
+++ b/task-manager/src/app/app.html
@@ -1,2 +1,1 @@
-<task-manager></task-manager>
-
+<router-outlet></router-outlet>

--- a/task-manager/src/app/app.routes.ts
+++ b/task-manager/src/app/app.routes.ts
@@ -1,3 +1,8 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  {
+    path: 'tasks',
+    loadChildren: () => import('../app/task-manager.routes').then(m => m.taskManagerRoutes)
+  }
+];

--- a/task-manager/src/app/app.ts
+++ b/task-manager/src/app/app.ts
@@ -1,9 +1,10 @@
 import { Component, signal } from '@angular/core';
 import {TaskManagerComponent} from '../components/task-manager-component/task-manager.component';
+import {RouterOutlet} from '@angular/router';
 
 @Component({
   selector: 'app-root',
-  imports: [TaskManagerComponent],
+  imports: [ RouterOutlet],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/task-manager/src/app/task-manager.routes.ts
+++ b/task-manager/src/app/task-manager.routes.ts
@@ -1,0 +1,23 @@
+import { Routes } from '@angular/router';
+import {TaskManagerComponent} from '../components/task-manager-component/task-manager.component';
+
+export const taskManagerRoutes: Routes = [
+  {
+    path: '', component: TaskManagerComponent,
+  children: [
+    {
+      path: '',
+      redirectTo: 'task-list',
+      pathMatch: 'full'
+    },
+  {
+    path: 'task-list',
+    loadComponent: () => import ('../pages/task-list-page/task-list-page.component').then(m => m.TaskListPageComponent)
+  },
+  {
+    path: 'task-item',
+    loadComponent: () => import ('../components/task-item/task-item.component').then(m => m.TaskItemComponent)
+  },
+    ]
+}
+];

--- a/task-manager/src/components/task-form/task-form.component.ts
+++ b/task-manager/src/components/task-form/task-form.component.ts
@@ -1,6 +1,7 @@
-import {Component, output} from '@angular/core';
+import {Component, inject, output} from '@angular/core';
 import { Task } from '../../models/task-model';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import {Router} from '@angular/router';
 
 @Component({
   selector: 'app-task-form',
@@ -11,6 +12,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
   ]
 })
 export class TaskFormComponent {
+  private router = inject(Router);
   public addTask = output<Task>();
 
   public taskForm = new FormGroup({
@@ -29,6 +31,13 @@ export class TaskFormComponent {
       } as Task;
       this.addTask.emit(newTask);
       this.taskForm.reset();
+      this.router.navigate(['/tasks/task-list']).then(success => {
+        if(success) {
+          console.log('Navigation to task list successful');
+        }
+      }).catch(error => {
+        console.error('Navigation to task list failed', error);
+      })
     }
   }
 }

--- a/task-manager/src/components/task-item/task-item.component.scss
+++ b/task-manager/src/components/task-item/task-item.component.scss
@@ -17,6 +17,7 @@
 
 .card {
   border-radius: 0.75rem;
+  margin: 10px;
 }
 
 .card-footer {

--- a/task-manager/src/components/task-manager-component/task-manager.component.html
+++ b/task-manager/src/components/task-manager-component/task-manager.component.html
@@ -1,11 +1,13 @@
-<div class="task-manager vh-100 vw-100 d-flex flex-column align-items-center justify-content-start p-4 bg-body-tertiary">
-  <div class="card w-100 mb-4" style="max-width: 600px;">
+<div class="task-manager d-flex flex-column align-items-center justify-content-start p-4 bg-body-tertiary">
+  <div class="card w-100 mb-4" style="max-width: 600px; width:100%;">
     <div class="card-body">
       <h1 class="card-title mb-3 text-center">Task Manager</h1>
-      <app-task-form (addTask)="addNewTask($event)"></app-task-form>
+      <nav class="mb-3 d-flex justify-content-center">
+        <a [routerLink]="['/tasks/task-list']" routerLinkActive="active" class="mx-2">Task List</a>
+      </nav>
+      <router-outlet></router-outlet>
     </div>
   </div>
   <div class="w-100" style="max-width: 600px;">
-    <app-task-list></app-task-list>
   </div>
 </div>

--- a/task-manager/src/components/task-manager-component/task-manager.component.scss
+++ b/task-manager/src/components/task-manager-component/task-manager.component.scss
@@ -23,5 +23,15 @@
     margin: 0;
   }
 
+  nav a.active {
+    text-decoration: underline;
+    color: #0d6efd;
+    font-weight: bold;
+    background-color: #e9ecef;
+    border-radius: 4px;
+    padding: 2px 8px;
+    transition: background 0.2s;
+  }
+
 }
 

--- a/task-manager/src/components/task-manager-component/task-manager.component.ts
+++ b/task-manager/src/components/task-manager-component/task-manager.component.ts
@@ -1,57 +1,38 @@
-import {Component, computed, inject, signal} from '@angular/core';
-import {TaskService} from '../../services/task-service';
-import {Task} from '../../models/task-model';
-import {TaskListComponent} from '../task-list/task-list.component';
-import {TaskFormComponent} from '../task-form/task-form.component';
+import {Component} from '@angular/core';
+import {RouterLink, RouterLinkActive, RouterOutlet} from '@angular/router';
+
+// const createTask: Task = {
+//   id: 0,
+//   title: '',
+//   description: '',
+//   completed: false
+// };
 
 @Component({
   selector: 'task-manager',
   imports: [
-    TaskListComponent,
-    TaskFormComponent
+    RouterOutlet,
+    RouterLink,
+    RouterLinkActive
   ],
   templateUrl: './task-manager.component.html',
   styleUrl: './task-manager.component.scss',
 })
+
 export class TaskManagerComponent {
-private readonly _taskService = inject(TaskService);
+// private readonly _taskService = inject(TaskService);
 
-public readonly tasks = this._taskService.tasks();
-
-public readonly defaultTask = signal<Task>({
-  id: 0,
-  title: '',
-  description: '',
-  completed: false
-});
-
-public currentTask = signal<Task>(this.defaultTask());
-
-public resetCurrentTask(): void {
-  this.currentTask.set(this.defaultTask());
-}
-
-public addNewTask(newTask: Task): void {
-  if (!newTask.id) {
-    newTask.id = Date.now();
-  }
-  this._taskService.addTask(newTask);
-  this.resetCurrentTask();
-}
-
-// public updateTask(updateTask: Task): void {
-//  this._taskService.updateTask(updateTask);
-//  this.resetCurrentTask();
+// public currentTask = signal<Task>({ ...createTask });
+//
+// public resetCurrentTask(): void {
+//   this.currentTask.set( { ...createTask } );
 // }
 //
-// public deleteTask(id: number): void {
-// this._taskService.deleteTask(id);
-// }
-//
-// public completeTask(id: number): void {
-//   const task = this._taskService.getTaskById(id);
-//   if (task) {
-//     this._taskService.updateTask({...task, completed: true});
+// public addNewTask(newTask: Task): void {
+//   if (!newTask.id) {
+//     newTask.id = Date.now();
 //   }
+//   this._taskService.addTask(newTask);
+//   this.resetCurrentTask();
 // }
 }

--- a/task-manager/src/main.ts
+++ b/task-manager/src/main.ts
@@ -1,5 +1,3 @@
-/// <reference types="@angular/localize" />
-
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';

--- a/task-manager/src/pages/task-list-page/task-list-page.component.html
+++ b/task-manager/src/pages/task-list-page/task-list-page.component.html
@@ -1,0 +1,9 @@
+<div class="d-flex justify-content-center my-3 " >
+  <div class="card" style="max-width: 600px; width: 100%;">
+    <div class="card-body">
+      <app-task-form (addTask)="addNewTask($event)"></app-task-form>
+      <app-task-list></app-task-list>
+  </div>
+  </div>
+</div>
+

--- a/task-manager/src/pages/task-list-page/task-list-page.component.spec.ts
+++ b/task-manager/src/pages/task-list-page/task-list-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TaskListPageComponent } from './task-list-page.component';
+
+describe('TaskListPageComponent', () => {
+  let component: TaskListPageComponent;
+  let fixture: ComponentFixture<TaskListPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TaskListPageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TaskListPageComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/task-manager/src/pages/task-list-page/task-list-page.component.ts
+++ b/task-manager/src/pages/task-list-page/task-list-page.component.ts
@@ -1,0 +1,20 @@
+import {Component, inject} from '@angular/core';
+import {TaskListComponent} from '../../components/task-list/task-list.component';
+import {TaskFormComponent} from '../../components/task-form/task-form.component';
+import {TaskService} from '../../services/task-service';
+import {Task} from '../../models/task-model';
+
+@Component({
+  selector: 'app-task-list-page',
+  imports: [TaskListComponent, TaskFormComponent],
+  templateUrl: './task-list-page.component.html',
+  styleUrl: './task-list-page.component.scss',
+  standalone: true,
+})
+export class TaskListPageComponent {
+  private taskService = inject(TaskService);
+
+  public addNewTask(newTask: Task): void {
+    this.taskService.addTask(newTask);
+  }
+}

--- a/task-manager/tsconfig.json
+++ b/task-manager/tsconfig.json
@@ -12,7 +12,7 @@
     "isolatedModules": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "ES2022",
+    "target": "es2023",
     "module": "preserve"
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
- Removed unused task form route and Add Task nav link; form is now part of Task List page
- Moved task list and add task form components into TaskListPageComponent as routed partial
- Cleaned up TaskManagerComponent by removing unused task-related logic and event emitters
- Updated parent template to contain only layout, nav, and <router-outlet>
- Set up default redirect from /tasks to /tasks/task-list for improved UX
- Ensured all task addition and list logic flows through shared TaskService